### PR TITLE
Remove inappopriate strip_tags from generateName

### DIFF
--- a/upload.php
+++ b/upload.php
@@ -53,7 +53,7 @@ function generateName($file)
 
         // Add the extension to the file name
         if (isset($ext) && $ext !== '') {
-            $name .= '.'.strip_tags($ext);
+            $name .= '.'.$ext;
         }
 
         // Check if a file with the same name does already exist in the database


### PR DESCRIPTION
This is not the place for file extension filtering.  Stripping tags anywhere else would not result in a valid link, either.